### PR TITLE
Added deltas argument to runHotNet2.py and hotnet2/run.py

### DIFF
--- a/hotnet2/run.py
+++ b/hotnet2/run.py
@@ -21,22 +21,25 @@ def run_helper(args, infmat_name, get_deltas_fn, extra_delta_args):
 
     infmat = hnio.load_infmat(args.infmat_file, infmat_name)
     full_index2gene = hnio.load_index(args.infmat_index_file)
-    
+
     using_json_heat = os.path.splitext(args.heat_file.lower())[1] == '.json'
     if using_json_heat:
         heat = json.load(open(args.heat_file))['heat']
     else:
         heat = hnio.load_heat_tsv(args.heat_file)
     print "* Loaded heat scores for %s genes" % len(heat)
-    
+
     # filter out genes not in the network
     heat = hnheat.filter_heat_to_network_genes(heat, set(full_index2gene.values()))
-    
+
     # genes with score 0 cannot be in output components, but are eligible for heat in permutations
     heat, addtl_genes = hnheat.filter_heat(heat, None, False, 'There are ## genes with heat score 0')
-    
-    deltas = get_deltas_fn(full_index2gene, heat, args.delta_permutations, args.num_cores, infmat, addtl_genes, *extra_delta_args)
-    
+
+    if args.deltas:
+        deltas = map(float, args.deltas)
+    else:
+        deltas = get_deltas_fn(full_index2gene, heat, args.delta_permutations, args.num_cores, infmat, addtl_genes, *extra_delta_args)
+
     sim, index2gene = hn.similarity_matrix(infmat, full_index2gene, heat, True)
 
     results_files = []
@@ -45,11 +48,11 @@ def run_helper(args, infmat_name, get_deltas_fn, extra_delta_args):
         delta_out_dir = args.output_directory + "/delta_" + str(delta)
         if not os.path.isdir(delta_out_dir):
             os.mkdir(delta_out_dir)
-        
+
         # find connected components
         G = hn.weighted_graph(sim, index2gene, delta, directed=True)
         ccs = hn.connected_components(G, args.min_cc_size)
-        
+
         # calculate significance (using all genes with heat scores)
         print "* Performing permuted heat statistical significance..."
         heat_permutations = p.permute_heat(heat, full_index2gene.values(),
@@ -65,7 +68,7 @@ def run_helper(args, infmat_name, get_deltas_fn, extra_delta_args):
         size2real_counts = dict(zip(sizes, real_counts))
         sizes2stats = stats.compute_statistics(size2real_counts, sizes2counts,
                                                args.significance_permutations)
-    
+
         # sort ccs list such that genes within components are sorted alphanumerically, and components
         # are sorted first by length, then alphanumerically by name of the first gene in the component
         ccs = [sorted(cc) for cc in ccs]
@@ -79,18 +82,18 @@ def run_helper(args, infmat_name, get_deltas_fn, extra_delta_args):
             json.dump(heat_dict, heat_out, indent=4)
             heat_out.close()
             args.heat_file = os.path.abspath(delta_out_dir) + "/" + HEAT_JSON
-        
+
         args.delta = delta  # include delta in parameters section of output JSON
         output_dict = {"parameters": vars(args), "sizes": hn.component_sizes(ccs),
                        "components": ccs, "statistics": sizes2stats}
         hnio.write_significance_as_tsv(os.path.abspath(delta_out_dir) + "/" + SIGNIFICANCE_TSV,
                                        sizes2stats)
-        
+
         json_out = open(os.path.abspath(delta_out_dir) + "/" + JSON_OUTPUT, 'w')
         json.dump(output_dict, json_out, indent=4)
         json_out.close()
         results_files.append( os.path.abspath(delta_out_dir) + "/" + JSON_OUTPUT )
-        
+
         hnio.write_components_as_tsv(os.path.abspath(delta_out_dir) + "/" + COMPONENTS_TSV, ccs)
 
     # create the hierarchy if necessary

--- a/hotnet2/run.py
+++ b/hotnet2/run.py
@@ -36,7 +36,7 @@ def run_helper(args, infmat_name, get_deltas_fn, extra_delta_args):
     heat, addtl_genes = hnheat.filter_heat(heat, None, False, 'There are ## genes with heat score 0')
 
     if args.deltas:
-        deltas = map(float, args.deltas)
+        deltas = args.deltas
     else:
         deltas = get_deltas_fn(full_index2gene, heat, args.delta_permutations, args.num_cores, infmat, addtl_genes, *extra_delta_args)
 

--- a/runHotNet2.py
+++ b/runHotNet2.py
@@ -26,10 +26,12 @@ def get_parser():
                               second column of each line.')
     parser.add_argument('-ccs', '--min_cc_size', type=int, default=2,
                         help='Minimum size connected components that should be returned.')
-    parser.add_argument('-pnp', '--permuted_networks_path', required=True,
+    parser.add_argument('-pnp', '--permuted_networks_path', required=False, default='',
                         help='Path to influence matrices for permuted networks. Include ' +\
                               ITERATION_REPLACEMENT_TOKEN + ' in the path to be replaced with the\
                               iteration number')
+    parser.add_argument('-d', '--deltas', nargs='*', default=[],
+                        help='Delta value(s).')
     parser.add_argument('-dp', '--delta_permutations', type=int, default=100,
                         help='Number of permutations to be used for delta parameter selection.')
     parser.add_argument('-sp', '--significance_permutations', type=int, default=100,
@@ -65,5 +67,5 @@ def run(args):
     extra_delta_args = [args.permuted_networks_path, INFMAT_NAME, MAX_CC_SIZES]
     hnrun.run_helper(args, INFMAT_NAME, hnrun.get_deltas_hotnet2, extra_delta_args)
 
-if __name__ == "__main__": 
+if __name__ == "__main__":
     run(get_parser().parse_args(sys.argv[1:]))

--- a/runHotNet2.py
+++ b/runHotNet2.py
@@ -30,7 +30,7 @@ def get_parser():
                         help='Path to influence matrices for permuted networks. Include ' +\
                               ITERATION_REPLACEMENT_TOKEN + ' in the path to be replaced with the\
                               iteration number')
-    parser.add_argument('-d', '--deltas', nargs='*', default=[],
+    parser.add_argument('-d', '--deltas', nargs='*', type=float, default=[],
                         help='Delta value(s).')
     parser.add_argument('-dp', '--delta_permutations', type=int, default=100,
                         help='Number of permutations to be used for delta parameter selection.')


### PR DESCRIPTION
This pull request adds a `deltas` argument to `runHotNet2.py`, allowing the user to specify \delta values instead of choosing them with the \delta selection procedure.  In particular, the user can use pre-computed \delta values, which is the intended use case.

I successfully ran this code for an experiment.